### PR TITLE
Fix double assignment in ExamplePlugin

### DIFF
--- a/ExamplePlugin/MySyncedConfig.cs
+++ b/ExamplePlugin/MySyncedConfig.cs
@@ -11,7 +11,7 @@ public class MySyncedConfig : SyncedConfig2<MySyncedConfig>
 
     public MySyncedConfig(ConfigFile configFile) : base(MyPluginInfo.PLUGIN_GUID)
     {
-        ClimbSpeed = ClimbSpeed = configFile.BindSyncedEntry(
+        ClimbSpeed = configFile.BindSyncedEntry(
             new ConfigDefinition("Movement", "Climb Speed"),
             3.9f,
             new ConfigDescription("The base speed at which the player climbs.")


### PR DESCRIPTION
Hi there. I used this example plugin to reproduce a bug in CSync. This patch doesn't matter, it's just a little cleanup.